### PR TITLE
WIP provisioning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision "shell", path: "bootstrap.sh"
+
+  config.vm.provider "virtualbox" do |v|
+      v.memory = 2048
+  end
+
+  config.vm.synced_folder ".", "/vagrant"
+  config.vm.synced_folder "../data/", "/vagrant/data/"  
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+sudo apt-get update
+
+# See: https://github.com/Toblerity/Fiona/issues/74
+#sudo apt-get install -y python-software-properties
+#sudo add-apt-repository ppa:ubuntugis/ppa
+#sudo apt-get update
+
+sudo apt-get install -y g++
+sudo apt-get install -y git
+sudo apt-get install -y gfortran
+sudo apt-get install -y build-essential
+sudo apt-get install -y python-pip
+sudo apt-get install -y python-all-dev
+sudo apt-get install -y python-gdal
+sudo apt-get install -y gdal-bin
+sudo apt-get install -y libgdal-dev
+sudo apt-get install -y openmpi-bin
+sudo apt-get install -y libopenmpi-dev
+sudo apt-get install -y proj-bin
+sudo apt-get install -y libtool
+sudo apt-get install -y libgeos-dev
+sudo apt-get install -y libblas-dev
+sudo apt-get install -y liblapack-dev
+sudo apt-get install -y libatlas-base-dev
+
+# Seems to need 2GB of RAM to install pip dependencies
+sudo pip install -U pip
+sudo pip install -r /vagrant/requirements.txt
+
+export PATH=/usr/local/bin:$PATH
+# This line was modified to include gdal which was not mentioned in the
+# Google Doc
+export CPATH=/usr/local/include:/usr/include/gdal:$CPATH
+export LIBRARY_PATH=/usr/local/lib:$LIBRARY_PATH
+export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+sudo mkdir /opt/taudem
+sudo chmod 777 /opt/taudem
+git clone https://github.com/dtarb/TauDEM.git /opt/taudem
+cd /opt/taudem
+make
+export PATH=/opt/taudem/:$PATH

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,8 @@
+Fiona==1.5.1
 nose==1.3.4
+numpy==1.10.1
+pandas==0.17.1
+pyshp==1.2.3
+scipy==0.16.1
+Shapely==1.2.19
+rapid_watershed_delineation==0.1.2


### PR DESCRIPTION
This builds on #2 to provision a VM that installs dependencies needed to run RWD. You will need to modify Vagrantfile to point at the right data directory. The data is in two zip files on a USB stick on my desk. After unzipping, the data should be arranged in the following structure.

```
Main_Watershed
Main_Watershed/Main_Watershed/
Main_Watershed/Subwatershed_ALL/
```

We were told by our colleagues at Utah that the contents of `Main_Watershed/Test1` should be deleted.

I found that the VM seems to need 2 GB of ram to install the dependencies. The step for cloning taudem could take a really long time.

The commands to run RWD on the VM:
```
cd /vagrant/rwd
python Rapid_Watershed_Delineation.py -75.276639 39.892986 1 10000 \
/vagrant/data/Main_Watershed Delaware_Ocean_stream_dissolve \
delaware_gw_5000_diss Delaware_Missing_Coast_Watershed \
DelDEMGeo2fel.tif DelDEMGeo2Max_elv_upslope.tif DelDEMGeo2ad8_slope_weighted.tif DelDEMGeo2ad8.tif \
DelDEMGeo2plen.tif DelDEMGeo2tlen_peuker.tif DelDEMGeo2gord_peuker.tif 1 /opt/taudem /usr/bin/
```