### PR TITLE
Set correct output directory for non-snapping path

### DIFF
--- a/rwd/Rapid_Watershed_Delineation.py
+++ b/rwd/Rapid_Watershed_Delineation.py
@@ -126,9 +126,11 @@ def Point_Watershed_Function(
             define_projection('Outlets_moved', 'New_Outlet', infile_crs[0])
             outlet_moved_file = os.path.join(Output_dir, "New_Outlet.shp")
         else:
+            os.chdir(Output_dir)
             define_projection('mypoint', 'New_Outlet', infile_crs[0])
             outlet_moved_file = os.path.join(Output_dir, "New_Outlet.shp")
     else:
+        os.chdir(Output_dir)
         define_projection('mypoint', 'New_Outlet', infile_crs[0])
         outlet_moved_file = os.path.join(Output_dir, "New_Outlet.shp")
 


### PR DESCRIPTION
Corrects a bug as patched on upstream:
https://github.com/nazmussazib/RapidWatersheDelineation/commit/9af76718afaa593a5b015951bb3b8ecb37d5e4d5

Where `mypoint.shp` could not be found in the target directory.

Connects #14 