### PR TITLE
Preserve source outlet and snapped point

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -4,6 +4,7 @@ import shutil
 from subprocess import call
 import json
 import tempfile
+import uuid
 
 from flask import Flask, jsonify, request
 
@@ -26,7 +27,8 @@ def error_response(error_message):
 def run_rwd(lat, lon):
     """
     Runs RWD for lat/lon and returns the GeoJSON
-    for the computed watershed boundary.
+    for the computed watershed boundary, outlet point
+    and snapped point.
     """
     snapping = request.args.get('snapping', '1')
     maximum_snap_distance = request.args.get('maximum_snap_distance', '10000')
@@ -60,21 +62,36 @@ def run_rwd(lat, lon):
             output_path
         )
 
-        output_shp_path = os.path.join(output_path, 'New_Point_Watershed.shp')
-        output_json_path = os.path.join(output_path, 'output.json')
-        call(['ogr2ogr', output_json_path, output_shp_path, '-f', 'GeoJSON'])
-        try:
-            with open(output_json_path, 'r') as output_json_file:
-                output = json.load(output_json_file)
-                shutil.rmtree(output_path)
-                return jsonify(**output)
-        except:
-            log.exception('Could not get GeoJSON from output')
-            return error_response('Could not get GeoJSON from output.')
+        # The Watershed and input coordinates (possibly snapped to stream)
+        # are written to disk.  Load them and convert to json
+        wshed_shp_path = os.path.join(output_path, 'New_Point_Watershed.shp')
+        input_shp_path = os.path.join(output_path, 'New_Outlet.shp')
+
+        output = {
+            'watershed': load_json(wshed_shp_path, output_path),
+            'input_pt': load_json(input_shp_path, output_path)
+        }
+
+        shutil.rmtree(output_path)
+        return jsonify(**output)
+
     except Exception as exc:
         log.exception('Error running Point_Watershed_Function')
         return error_response(exc.message)
 
+
+def load_json(shp_path, output_path):
+    name = '%s.json' % uuid.uuid4().hex
+    output_json_path = os.path.join(output_path, name)
+    call(['ogr2ogr', output_json_path, shp_path, '-f', 'GeoJSON'])
+
+    try:
+        with open(output_json_path, 'r') as output_json_file:
+            output = json.load(output_json_file)
+            return output
+    except:
+        log.exception('Could not get GeoJSON from output.')
+        return None
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0")


### PR DESCRIPTION
The results of RWD now include the source outlet point and the snapped
point (as properties on the outlet) if snapping was enabled, along with
the polygon of the computed watershed.

To Test:

* Visit http://localhost:5000/rwd/-75.276639/39.692986?snapping=1 and check that a new data structure is returned with the watershed polygon and the input point.  Because snapping is enabled, check that the coordinates are _not_ the same as the input.  The input should be preserved as attributes in the properties of the feature.

* Visit http://localhost:5000/rwd/-75.276639/39.692986?snapping=0 and check that watershed is null (the RWD hill slope does not produce a file for this coordinate).  Since snapping is off, the `input_pt` should have the same coordinates as the url input.

Partially Connects https://github.com/WikiWatershed/model-my-watershed/issues/1085