### PR TITLE
Maintain Original LatLng Projection In Input Point Properties (Lat, Lon)

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -8,7 +8,6 @@ import uuid
 import traceback
 
 import ogr
-import osr
 from flask import Flask, jsonify, request, render_template
 
 from rwd_drb import Rapid_Watershed_Delineation
@@ -106,20 +105,13 @@ def run_rwd_nhd(lat, lon):
     num_processors = '1'
     data_path = '/opt/rwd-data/nhd'
 
-    albers_lat, albers_lon = reproject_point(
-        (lat, lon),
-        # WGS 84 Latlong
-        from_epsg=4326,
-        # NAD83 / Conus Albers
-        to_epsg=5070)
-
     # Create a temporary directory to hold the output.
     output_path = tempfile.mkdtemp()
 
     try:
         NHD_Rapid_Watershed_Delineation.Point_Watershed_Function(
-            albers_lon,
-            albers_lat,
+            float(lon),
+            float(lat),
             snapping,
             maximum_snap_distance,
             data_path,
@@ -182,30 +174,6 @@ def load_json(shp_path, output_path, simplify_tolerance=None,
     except:
         log.exception('Could not get GeoJSON from output.')
         return None
-
-
-def reproject_point(lat_lon, from_epsg, to_epsg):
-    """
-    Source: http://gis.stackexchange.com/a/78850
-    """
-    lat, lon = lat_lon
-
-    lat = float(lat)
-    lon = float(lon)
-
-    point = ogr.Geometry(ogr.wkbPoint)
-    point.AddPoint(lon, lat)
-
-    inSpatialRef = osr.SpatialReference()
-    inSpatialRef.ImportFromEPSG(from_epsg)
-
-    outSpatialRef = osr.SpatialReference()
-    outSpatialRef.ImportFromEPSG(to_epsg)
-
-    coordTransform = osr.CoordinateTransformation(inSpatialRef, outSpatialRef)
-    point.Transform(coordTransform)
-
-    return point.GetY(), point.GetX()
 
 def get_shp_area(shp_file_path):
     driver = ogr.GetDriverByName("ESRI Shapefile")


### PR DESCRIPTION
## Overview
The MMW frontend uses the returned feature's properties to show the original point (as opposed to the snapped one). We were returning the original point in its projected EPSG: 5070 coordinates, not the original LatLng projection. 
_Only one point_
<img width="338" alt="screen shot 2016-11-11 at 11 10 00 am" src="https://cloud.githubusercontent.com/assets/7633670/20221457/6b2e6558-a7ff-11e6-8a28-47308940333c.png">
```
  "input_pt": {
        "crs": {
            "type": "name",
            "properties": {
                "name": "urn:ogc:def:crs:OGC:1.3:CRS84"
            }
        },
        "type": "FeatureCollection",
        "features": [
            {
                "geometry": {
                    "type": "Point",
                    "coordinates": [
                        -75.70075369516621,
                        40.31170565096853
                    ]
                },
                "type": "Feature",
                "properties": {
                    "Lat": 2104252.672046, <--- Not LatLng
                    "Dist_moved": 21,      
                    "Lon": 1696736.868729, <----
                    "ID": 1
                }
            }
        ]
    }
```
## Testing Instructions
- Pull this branch and the latest https://github.com/WikiWatershed/docker-rwd
- Follow the instructions in #37 to
  -    mount the RWD data with Docker Toolbox if you're on a Mac
  -    build/run the docker container
- Run a few points like this:
`http http://localhost:5000/rwd-nhd/39.0458/-76.6413` 
and confirm the payload returns an `input_pt` with `properities.Lat` and `properties.Lon` projected to EPSG: 4326



Connects #40 