### PR TITLE
Use docker-compose up instead of run

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,28 @@ Folder structure:
     |-- Subwatershed_ALL
 ```
 
+### Running inside Model My Watershed
+
+To run RWD inside the MMW application during development, follow these
+instructions.
+
+In the MMW project:
+
+```
+# Change the rwd_host setting to 10.0.2.2
+vim deployment/ansible/roles/model-my-watershed.rwd/defaults/main.yml
+vagrant reload worker --provision
+```
+
+Note that `10.0.2.2` should point to your host machine. Verify this by running
+`route -n` inside the worker VM. It should be the default gateway.
+
+Then in this project, run:
+
+```
+./scripts/server.sh
+```
+
 ## Deployments
 
 To create a new release, use the following git commands:

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -4,14 +4,6 @@ set -e
 
 echo "Run the RWD Docker container."
 
-if [ -z "$RWD_DATA" ]; then
-    echo "Environment variable RWD_DATA not defined."
-    exit 1
-fi
-
 set -x
 
-docker-compose run \
-    --rm \
-    -e RWD_DATA=$RWD_DATA \
-    app
+docker-compose up


### PR DESCRIPTION
This fixes an issue where the RWD service ports are not mapped when the
server command is running, which results in the following error:

```
> curl http://localhost:5000
curl: (7) Failed to connect to localhost port 5000: Connection refused
```