### PR TITLE
Update README to fix latlng order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ A docker image and fork of @nazmussazib's [Rapid Watershed Delineation](https://
 * Run `./scripts/update.sh`
 * Run `./scripts/server.sh`
 
-#### Linux
+#### Linux & Docker for Mac on macOS
 * Run `curl http://localhost:5000/rwd/39.892986/-75.276639`
 
-#### OS X
+#### Docker Machine on macOS
 * Find the IP of the default VM using `docker-machine ip default`
 * Run `curl http://<default_vm_ip>:5000/rwd/39.892986/-75.276639`
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ A docker image and fork of @nazmussazib's [Rapid Watershed Delineation](https://
 * Run `./scripts/server.sh`
 
 #### Linux
-* Run `curl http://localhost:5000/rwd/-75.276639/39.892986`
+* Run `curl http://localhost:5000/rwd/39.892986/-75.276639`
 
 #### OS X
 * Find the IP of the default VM using `docker-machine ip default`
-* Run `curl http://<default_vm_ip>:5000/rwd/-75.276639/39.892986`
+* Run `curl http://<default_vm_ip>:5000/rwd/39.892986/-75.276639`
 
 ### Environment Variables
 


### PR DESCRIPTION
## Overview

This PR updates the README to adjust the coordinate order in the example urls. After setting this project up, I encountered an error when using the prior example urls.

## Testing
- get and run the container, then try out the prior example endpoints and confirm that the response includes an error noting that the point is outside the watershed
- try the updated example endpoints and verify that it returns results