### PR TITLE
Add option to retrieve unsimplified result

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+
+Brief description of what this PR does, and why it is needed.
+
+Connects #XXX
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
+## Testing Instructions
+
+* How to test this PR
+* Prefer bulleted description
+* Start after checking out this branch
+* Include any setup required, such as bundling scripts, restarting services, etc.
+* Include test case, and expected output

--- a/README.md
+++ b/README.md
@@ -75,3 +75,19 @@ $ git flow release publish 0.1.0
 $ git flow release finish 0.1.0
 $ git push --tags
 ```
+
+## RWD API
+
+### Request
+
+| Name | Method | Description |
+| ---- | ------ | ----------- |
+| /rwd/lat/lng | GET | Run RWD for DRB for client-supplied `<lat>` & `<lng>` coordinates. |
+| /rwd-nhd/lat/lng | GET | Run RWD for NHD for client-supplied `<lat>` & `<lng>` coordinates. |
+
+### Parameters
+
+| Name | Type | Required/Optional | Description |
+| ---- | ---- | ----------------- | ----------- |
+| simplify | number | optional | Simplify tolerance for response GeoJSON. Request unsimplified shape with `simplify=0`. Defaults to `0.0001` for DRB and is [derived from the shape's area](https://github.com/WikiWatershed/rapid-watershed-delineation/blob/1.2.1/src/api/main.py#L195) for NHD when not supplied. |
+| maximum_snap_distance | number | optional | Maximum distance to snap input point. Defaults to `10000` when not supplied. |

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -84,9 +84,14 @@ def run_rwd(lat, lon):
         wshed_shp_path = os.path.join(output_path, 'New_Point_Watershed.shp')
         input_shp_path = os.path.join(output_path, 'New_Outlet.shp')
 
+        wshed_json = load_json(wshed_shp_path, output_path) if simplify == "0" \
+            else load_json(wshed_shp_path, output_path, simplify)
+
+        input_pt_json = load_json(input_shp_path, output_path)
+
         output = {
-            'watershed': load_json(wshed_shp_path, output_path, simplify),
-            'input_pt': load_json(input_shp_path, output_path)
+            'watershed': wshed_json,
+            'input_pt': input_pt_json
         }
 
         shutil.rmtree(output_path)
@@ -137,13 +142,20 @@ def run_rwd_nhd(lat, lon):
             'simplify',
             create_simplify_tolerance_by_area(wshed_shp_path)))
 
-        output = {
-            'watershed': load_json(wshed_shp_path, output_path, simplify,
-                                   # From NAD83 / Conus Albers to WGS 84 Latlong
-                                   from_epsg=5070, to_epsg=4326),
-            'input_pt': load_json(input_shp_path, output_path,
-                                  # From NAD83 / Conus Albers to WGS 84 Latlong
+        # Reproject from NAD83/Conus Albers to WGS84/LatLng
+        if simplify == "0":
+            watershed_json = load_json(wshed_shp_path, output_path,
+                                       from_epsg=5070, to_epsg=4326)
+        else:
+            watershed_json = load_json(wshed_shp_path, output_path, simplify,
+                                       from_epsg=5070, to_epsg=4326)
+
+        input_pt_json = load_json(input_shp_path, output_path,
                                   from_epsg=5070, to_epsg=4326)
+
+        output = {
+            'watershed': watershed_json,
+            'input_pt': input_pt_json
         }
 
         shutil.rmtree(output_path)


### PR DESCRIPTION
## Overview

This PR adds & documents an option to retrieve an unsimplified shape for the RWD result.

This was previously possible by passing in a `?simplify=0` query parameter which would have set ogr2ogr's simplify tolerance to 0 when creating the geojson output, but these changes add an explicit check for whether the paramenter `== "0"` and -- if so -- we don't pass ` -simplify` argument to ogr2ogr at all.

Second commit here documents the `simplify` param in the readme, along with the `maximum_snap_distance`.

Third one adds the usual pull request template.

Connects #71 

## Testing
- get this branch, then configure & start RWD
- test out both the DRB and NHD endpoints according to the instructions in the README and verify that they work as expected. In particular:
    - using `?simplify=0` should return essentially similar shape coordinates for DRB as not using the param
    - using `?simplify=0` for NHD may return different shape coordinates than not using it -- the degree of difference will depend on the size of the generated shape 
    - using `?simplify=10` for either endpoint should return a shape with fewer coordinate points.