### PR TITLE
Round watershed coordinates to 5 trailing digits

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -171,7 +171,8 @@ def load_json(shp_path, output_path, simplify_tolerance=None,
               from_epsg=None, to_epsg=None):
     name = '%s.json' % uuid.uuid4().hex
     output_json_path = os.path.join(output_path, name)
-    ogr_cmd = ['ogr2ogr', output_json_path, shp_path, '-f', 'GeoJSON']
+    ogr_cmd = ['ogr2ogr', output_json_path, shp_path, '-f', 'GeoJSON', '-lco',
+               'COORDINATE_PRECISION=5']
 
     # Simplify the polygon as we convert to JSON if there
     # is a tolerance setting


### PR DESCRIPTION
## Overview

This PR reduces the watershed geojson payload size by rounding its coordinates to 5 trailing digits. 

To accomplish this, I added an `adjust_coordinate_precision` function which takes a list of features and returns a list of features with their coordinates rounded to a given precision which currently defaults to 5. Inside the function there are a few helpers which use list comprehensions to traverse the features and round the coordinates; the `round_to_precision` helper ultimately does the rounding and either returns a rounded number or a list of rounded numbers to accommodate both polygon and multipolygon shapes.

Connects #72

## Notes

As discussed in the comments on https://github.com/WikiWatershed/rapid-watershed-delineation/issues/72 I tried out using ogr2ogr's `COORDINATE_PRECISION=5` option, but kept encountering an error related to the GeoJSON driver. Not sure why that is because it seems to be a documented possibility here -- http://www.gdal.org/drv_geojson.html -- but it may be that it's only available on reads and not writes?

Ultimately I adapted the implementation of this library -- https://github.com/perrygeo/geojson-precision -- a link to which I added in the `adjust_coord_precision` docstring.

I did not simplify the point json coordinates since presumably those makes up a small piece of the payload, but we could do so for regularity's sake.

Only d0115b6 is from this PR; the rest are for #71

## Testing
- get this branch then set up and launch RWD
- try posting some points to both /rwd and /rwd-nhd and verify that you see the watershed coordinates rounded to 5 trailing digits. Probably worth checking that the prior digits match develop

http://localhost:5000/rwd/39.978101851904135/-75.4615277777516 has MultiPolygon nesting

http://localhost:5000/rwd/39.892986/-75.276639 has Polygon nesting

Both seem to be features as far as RWD is concerned, but it seems like we parse them into Polygon and MultiPolygon shapes in MMW.

- verify that the adjusted coordinate precision is still enough to be accurate in the frontend