### PR TITLE
Round RWD shape latlngs to 6 trailing decimal places

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -172,7 +172,7 @@ def load_json(shp_path, output_path, simplify_tolerance=None,
     name = '%s.json' % uuid.uuid4().hex
     output_json_path = os.path.join(output_path, name)
     ogr_cmd = ['ogr2ogr', output_json_path, shp_path, '-f', 'GeoJSON', '-lco',
-               'COORDINATE_PRECISION=5']
+               'COORDINATE_PRECISION=6']
 
     # Simplify the polygon as we convert to JSON if there
     # is a tolerance setting


### PR DESCRIPTION
## Overview

This PR adjusts the coordinate precision of the RWD shape latlngs to have 6 trailing decimal places; previously they had 5.

Connects #77 

## Demo

<img width="757" alt="screen shot 2017-10-06 at 9 55 01 am" src="https://user-images.githubusercontent.com/4165523/31281105-7ae1a69c-aa7c-11e7-9b2d-289f1d4fc141.png">


## Testing Instructions
- get this branch, then set up the RWD data
- test http://localhost:5000/rwd/39.892986/-75.276639 and http://localhost:5000/rwd-nhd/39.892986/-75.276639 and verify that the resulting watershed shape has 6 trailing decimals
