### PR TITLE
Return GeoJSON Features, Not Feature Collections

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -188,7 +188,8 @@ def load_json(shp_path, output_path, simplify_tolerance=None,
     try:
         with open(output_json_path, 'r') as output_json_file:
             output = json.load(output_json_file)
-            return output
+            output_feature = output.get('features')[0]
+            return output_feature
     except:
         log.exception('Could not get GeoJSON from output.')
         return None


### PR DESCRIPTION
`watershed` and `input_pt` feature collections always
contain a single feature. Return just this feature
for better compatibility with the MMW API.

Connects https://github.com/WikiWatershed/model-my-watershed/issues/2449

### Demo

```json
{
  "input_pt": {
    "geometry": {
      "coordinates": [
        -75.276806,
        39.892917
      ],
      "type": "Point"
    },
    "properties": {
      "Dist_moved": 3,
      "ID": 1,
      "Lat": 39.892986,
      "Lon": -75.276639
    },
    "type": "Feature"
  },
  "watershed": {
    "geometry": {
      "coordinates": [
        [
          [
            -75.277778,
            39.896296
          ],
          [
            -75.277593,
            39.896296
          ],
...
        ]
      ],
      "type": "Polygon"
    },
    "properties": {
      "Area": 0.064926565,
      "AvgOLF": 0.379189616299114,
      "Avgslp": 0.052553854882717,
      "BR": 14.96755599975586,
      "BasinLen": 0.505920379638672,
      "DrnDen": 1.318601508342961,
      "GRIDCODE": 1,
      "RR": 0.029584804549813,
      "StrLen": 0.085612266540527,
      "Strord": 1.0
    },
    "type": "Feature"
  }
```

## Notes

I tried using the `ogr2ogr` geojson open option [`FLATTEN_NESTED_ATTRIBUTES`](http://www.gdal.org/drv_geojson.html), but it didn't have an effect on the output. 

## Testing Instructions

* Pull this branch, `update` and `server`
 * `curl http://localhost:5000/rwd/39.892986/-75.276639`
 * `curl http://localhost:5000/rwd-nhd/39.892986/-75.276639`

Confirm the output assumes the expected shape.
