### PR TITLE
Update Docker Image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,35 +1,52 @@
 name: release
 
 on:
-    push:
-      tags: "*"
+  push:
+    tags: "*"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: WikiWatershed/rwd
 
 jobs:
-    release:
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@v4
+  release:
+    runs-on: ubuntu-latest
 
-            - name: Set SHA_TAG
-              run: |
-                echo "SHA_TAG=`git rev-parse --short HEAD`" >> $GITHUB_ENV
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
 
-            - name: Setup Docker Buildx
-              uses: docker/setup-buildx-action@v3
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
 
-            - name: Login to Quay
-              uses: docker/login-action@v3
-              with:
-                registry: quay.io
-                username: ${{ secrets.QUAY_USERNAME }}
-                password: ${{ secrets.QUAY_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Build and push
-              uses: docker/build-push-action@v6
-              with:
-                push: true
-                tags: |
-                  quay.io/wikiwatershed/rwd:${SHA_TAG}
-                  quay.io/wikiwatershed/rwd:${{ github.ref_name }}
-                  quay.io/wikiwatershed/rwd:latest
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/wikiwatershed/taudem:5.3.8
+FROM ghcr.io/wikiwatershed/taudem:5.3.8-xenial
 
 MAINTAINER Azavea <systems@azavea.com>
 


### PR DESCRIPTION
## Overview

We need to update the Docker image and publish it in the new format. This PR does that.

It also switches the publishing to GitHub Container Registry instead of Quay, since this is more central and integrated, and the Quay WikiWatershed organization is unmaintained.

Closes #83 

